### PR TITLE
fix: remove stale resume unit reference

### DIFF
--- a/system/99-react-drm.rules
+++ b/system/99-react-drm.rules
@@ -26,12 +26,8 @@ SUBSYSTEM=="input", ATTR{name}=="Mac14,7 Touch Bar", ENV{ID_SEAT}="seat-touchbar
 # alone is not enough — powertop --auto-tune flips it back to auto without a
 # uevent — so autosuspend_delay_ms=-1 pins a second, independent usage-count
 # reference that blocks runtime suspend even with control=auto.
-# The systemd tag + SYSTEMD_USER_WANTS start react-drm-resume.service whenever
-# the device (re-)enumerates, which restarts react-drm after S3 resume (the t2
-# sleep hook reloads apple_bce, so the bar comes back as a brand-new device and
-# the running app would otherwise keep drawing into a dead DRM fd).
 #ACTION=="add", SUBSYSTEM=="usb", ATTR{idVendor}=="05ac", ATTR{idProduct}=="8302", ATTR{bConfigurationValue}=="1", ATTR{bConfigurationValue}="0", ATTR{bConfigurationValue}="1"
-ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="05ac", ATTR{idProduct}=="8302", GROUP="video", MODE="0660", RUN+="/bin/chown root:video /sys%p/bConfigurationValue", RUN+="/bin/chmod g+w /sys%p/bConfigurationValue", ATTR{power/control}="on", ATTR{power/autosuspend_delay_ms}="-1", TAG+="systemd", ENV{SYSTEMD_USER_WANTS}="react-drm-resume.service"
+ACTION=="add", SUBSYSTEM=="usb", ENV{DEVTYPE}=="usb_device", ATTR{idVendor}=="05ac", ATTR{idProduct}=="8302", GROUP="video", MODE="0660", RUN+="/bin/chown root:video /sys%p/bConfigurationValue", RUN+="/bin/chmod g+w /sys%p/bConfigurationValue", ATTR{power/control}="on", ATTR{power/autosuspend_delay_ms}="-1"
 
 # Backlight: let the video group set Touch Bar brightness without sudo.
 ACTION=="add", SUBSYSTEM=="backlight", KERNEL=="appletb_backlight", RUN+="/bin/chown root:video /sys/class/backlight/%k/brightness", RUN+="/bin/chmod g+w /sys/class/backlight/%k/brightness"


### PR DESCRIPTION
Removes the stale `react-drm-resume.service` reference from the udev rule.
Suspend and resume are now handled in-process, and the referenced service does not exist.