### PR TITLE
fix: avoid keyboard reconnect during resume

### DIFF
--- a/linux-touchbar-control-center/index.tsx
+++ b/linux-touchbar-control-center/index.tsx
@@ -55,7 +55,9 @@ async function main() {
       onSleep: () => result.suspend(),
       onResume: async () => {
         await attachTouchBar();
-        keyboard.reconnect();
+        // KeyboardReader already auto-reconnects on device loss. Forcing a
+        // fresh udev enumeration here races the BCE/T2 resume path and can
+        // abort inside libudev before the input tree is stable again.
         result.resume();
       },
     }).catch(e => {


### PR DESCRIPTION
react-drm forced a keyboard re-enumeration on resume even though KeyboardReader already auto-reconnects after device loss. On T2 resume this races the BCE/input re-enumeration and can abort inside libudev while scanning input devices, leaving the Touch Bar frozen and built-in input unavailable until reboot. Or in other words: apletbdrm/hid_appletb_kbd was dead after resume.