### PR TITLE
Adds browser MPRIS progress support to the touchbar media panel.

### DIFF
--- a/linux-touchbar-control-center/hooks/useMediaPlayers.ts
+++ b/linux-touchbar-control-center/hooks/useMediaPlayers.ts
@@ -1,12 +1,12 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
 import dbus, { MessageBus, Variant } from 'dbus-next';
 
-// Spotify registers a single MPRIS2 service. Chrome itself has no native MPRIS2
-// service on Linux; on KDE Plasma the `plasma-browser-integration` Chrome
-// extension exposes browser media sessions over D-Bus.
+// Spotify exposes a stable MPRIS2 service. Browser media support in this app
+// comes from plasma-browser-integration, which exports the active browser
+// session over MPRIS with working metadata / position on the systems we target.
 const PLAYER_CONFIGS = [
   { prefix: 'org.mpris.MediaPlayer2.spotify', name: 'spotify' as const },
-  { prefix: 'org.mpris.MediaPlayer2.plasma-browser-integration', name: 'chrome' as const },
+  { prefix: 'org.mpris.MediaPlayer2.plasma-browser-integration', name: 'browser' as const },
 ];
 
 const OBJ    = '/org/mpris/MediaPlayer2';
@@ -21,13 +21,17 @@ export interface MediaPlayerState {
   status: PlayerStatus;
   /** Album-art URL from MPRIS `mpris:artUrl` (http/https/file/data), or '' if none. */
   artUrl: string;
+  /** Current position in microseconds. */
+  positionUs: number;
+  /** Total track length in microseconds, 0 when unknown. */
+  lengthUs: number;
 }
 
 export interface MediaPlayer {
   /** D-Bus service name, e.g. `org.mpris.MediaPlayer2.spotify`. */
   service: string;
-  /** Human-readable source: `chrome` (via plasma-browser-integration) or `spotify`. */
-  name: 'chrome' | 'spotify';
+  /** Human-readable source. */
+  name: 'browser' | 'spotify';
   /** Current playback state. */
   state: MediaPlayerState;
   /** Toggle play/pause on this player. */
@@ -36,11 +40,34 @@ export interface MediaPlayer {
   next(): void;
   /** Go back to the previous track. */
   previous(): void;
+  /** Seek to an absolute position in microseconds. */
+  seek(positionUs: number): void;
 }
 
-const IDLE: MediaPlayerState = { title: '', artist: '', status: 'Stopped', artUrl: '' };
+const IDLE: MediaPlayerState = {
+  title: '',
+  artist: '',
+  status: 'Stopped',
+  artUrl: '',
+  positionUs: 0,
+  lengthUs: 0,
+};
 
-function readMeta(meta: Record<string, Variant> | undefined): Pick<MediaPlayerState, 'title' | 'artist' | 'artUrl'> {
+function num(v: unknown): number {
+  return typeof v === 'bigint' ? Number(v) : typeof v === 'number' ? v : 0;
+}
+
+function matchPlayerConfig(service: string) {
+  return PLAYER_CONFIGS.find(c => service.startsWith(c.prefix));
+}
+
+function normalizeServices(names: string[]): string[] {
+  return names
+    .filter(name => matchPlayerConfig(name))
+    .sort((a, b) => a.localeCompare(b));
+}
+
+function readMeta(meta: Record<string, Variant> | undefined): Pick<MediaPlayerState, 'title' | 'artist' | 'artUrl' | 'lengthUs'> {
   const m = meta ?? {};
   const artistRaw = m['xesam:artist']?.value;
   let title = (m['xesam:title']?.value as string) ?? '';
@@ -53,6 +80,7 @@ function readMeta(meta: Record<string, Variant> | undefined): Pick<MediaPlayerSt
     title,
     artist: Array.isArray(artistRaw) ? artistRaw.join(', ') : ((artistRaw as string) ?? ''),
     artUrl: (m['mpris:artUrl']?.value as string) ?? '',
+    lengthUs: num(m['mpris:length']?.value),
   };
 }
 
@@ -76,6 +104,7 @@ export function useMediaPlayers(): UseMediaPlayersResult {
   const [states,   setStates]   = useState<Record<string, MediaPlayerState>>({});
   const [loading,  setLoading]  = useState(true);
   const busRef = useRef<MessageBus | null>(null);
+  const trackIdsRef = useRef<Record<string, string>>({});
 
   // ── Track matching MPRIS service names on the session bus ──────────────────
   useEffect(() => {
@@ -90,18 +119,18 @@ export function useMediaPlayers(): UseMediaPlayersResult {
       const diface = dobj.getInterface('org.freedesktop.DBus');
       diface.on('NameOwnerChanged', (name: string, _old: string, newOwner: string) => {
         if (!alive) return;
-        const match = PLAYER_CONFIGS.find(c => name.startsWith(c.prefix));
+        const match = matchPlayerConfig(name);
         if (!match) return;
         if (newOwner) svcs.add(name); else svcs.delete(name);
-        sync();
+        alive && setServices(normalizeServices([...svcs]));
       });
       const names: string[] = await diface.ListNames();
       if (!alive) return;
       names.forEach(name => {
-        const match = PLAYER_CONFIGS.find(c => name.startsWith(c.prefix));
+        const match = matchPlayerConfig(name);
         if (match) svcs.add(name);
       });
-      sync();
+      alive && setServices(normalizeServices([...svcs]));
     })().catch(() => {}).finally(() => { if (alive) setLoading(false); });
 
     return () => { alive = false; busRef.current = null; bus.disconnect(); };
@@ -116,45 +145,84 @@ export function useMediaPlayers(): UseMediaPlayersResult {
 
     services.forEach(service => {
       (async () => {
+        const match = matchPlayerConfig(service);
         const obj    = await bus.getProxyObject(service, OBJ);
         if (!alive) return;
         const props  = obj.getInterface(PROPS);
         const player = obj.getInterface(PLAYER);
 
-        const applyAll = async () => {
+        const refreshPosition = async () => {
+          try {
+            const reply = await bus.call(new dbus.Message({
+              destination: service,
+              path: OBJ,
+              interface: PROPS,
+              member: 'Get',
+              signature: 'ss',
+              body: [PLAYER, 'Position'],
+            }));
+            if (!alive) return;
+            const positionUs = num((reply?.body[0] as Variant | undefined)?.value);
+            setStates(prev => {
+              const current = prev[service] ?? IDLE;
+              if (Math.abs(current.positionUs - positionUs) < 50_000) return prev;
+              return { ...prev, [service]: { ...current, positionUs } };
+            });
+          } catch { /* player closed or doesn't expose Position */ }
+        };
+
+        const refreshAll = async () => {
           try {
             const all = await props.GetAll(PLAYER) as Record<string, Variant>;
             if (!alive) return;
             const meta = all.Metadata?.value as Record<string, Variant> | undefined;
+            trackIdsRef.current[service] = (meta?.['mpris:trackid']?.value as string) ?? '';
             setStates(prev => ({
               ...prev,
               [service]: {
                 ...readMeta(meta),
                 status: (all.PlaybackStatus?.value as PlayerStatus) ?? 'Stopped',
+                positionUs: num(all.Position?.value),
               },
             }));
+            void refreshPosition();
           } catch { /* player closed */ }
         };
 
         props.on('PropertiesChanged', (iface: string, changed: Record<string, Variant>) => {
           if (!alive || iface !== PLAYER) return;
+          let refreshAfter = false;
           setStates(prev => {
             const current = prev[service] ?? IDLE;
             const next: MediaPlayerState = { ...current };
             if (changed.PlaybackStatus) next.status = changed.PlaybackStatus.value as PlayerStatus;
-            if (changed.Metadata) Object.assign(next, readMeta(changed.Metadata.value as Record<string, Variant>));
-        
+            if (changed.Metadata) {
+              const meta = changed.Metadata.value as Record<string, Variant>;
+              trackIdsRef.current[service] = (meta['mpris:trackid']?.value as string) ?? '';
+              Object.assign(next, readMeta(meta));
+              refreshAfter = true;
+            }
+            if (changed.Position) next.positionUs = num(changed.Position.value);
             if (next.title === current.title && next.artist === current.artist
-                && next.status === current.status && next.artUrl === current.artUrl) {
+                && next.status === current.status && next.artUrl === current.artUrl
+                && next.positionUs === current.positionUs && next.lengthUs === current.lengthUs) {
               return prev;
             }
             return { ...prev, [service]: next };
           });
+          if (changed.PlaybackStatus || refreshAfter) void refreshPosition();
         });
 
-        await applyAll();
+        player.on('Seeked', () => { void refreshPosition(); });
+        const posPoll = setInterval(() => { void refreshPosition(); }, 500);
+        const fullPoll = match?.name === 'browser'
+          ? setInterval(() => { void refreshAll(); }, 1000)
+          : null;
+        await refreshAll();
 
         cleanups.push(() => {
+          clearInterval(posPoll);
+          if (fullPoll) clearInterval(fullPoll);
           props.removeAllListeners('PropertiesChanged');
           player.removeAllListeners('Seeked');
         });
@@ -179,10 +247,24 @@ export function useMediaPlayers(): UseMediaPlayersResult {
   const playPause = useCallback((service?: string) => send(service, 'PlayPause'), [send]);
   const next      = useCallback((service?: string) => send(service, 'Next'),      [send]);
   const previous  = useCallback((service?: string) => send(service, 'Previous'),  [send]);
+  const seek = useCallback((service: string | undefined, positionUs: number) => {
+    const bus = busRef.current;
+    const svc = service ?? services[0];
+    const trackId = svc ? trackIdsRef.current[svc] : '';
+    if (!bus || !svc || !trackId) return;
+    bus.call(new dbus.Message({
+      destination: svc,
+      path: OBJ,
+      interface: PLAYER,
+      member: 'SetPosition',
+      signature: 'ox',
+      body: [trackId, BigInt(Math.max(0, Math.round(positionUs)))],
+    })).catch(() => {});
+  }, [services]);
 
   const players = useMemo<MediaPlayer[]>(() => {
     return services.map(service => {
-      const match = PLAYER_CONFIGS.find(c => service.startsWith(c.prefix));
+      const match = matchPlayerConfig(service);
       return {
         service,
         name: match?.name ?? 'spotify',
@@ -190,9 +272,10 @@ export function useMediaPlayers(): UseMediaPlayersResult {
         playPause: () => playPause(service),
         next:      () => next(service),
         previous:  () => previous(service),
+        seek:      (positionUs: number) => seek(service, positionUs),
       };
     });
-  }, [services, states, playPause, next, previous]);
+  }, [services, states, playPause, next, previous, seek]);
 
   const show = players.length > 0;
 

--- a/linux-touchbar-control-center/index.tsx
+++ b/linux-touchbar-control-center/index.tsx
@@ -55,7 +55,9 @@ async function main() {
       onSleep: () => result.suspend(),
       onResume: async () => {
         await attachTouchBar();
-        keyboard.reconnect();
+        // KeyboardReader already auto-reconnects on device loss. Forcing a
+        // fresh udev enumeration here races the BCE/T2 resume path and can
+        // abort inside libudev before the input tree is stable again.
         result.resume();
       },
     }).catch(e => {

--- a/linux-touchbar-control-center/layers/leftsideLayers/MediaMprisList.tsx
+++ b/linux-touchbar-control-center/layers/leftsideLayers/MediaMprisList.tsx
@@ -1,18 +1,28 @@
-import React, { useEffect, useMemo, useState } from 'react';
-import { Box, Text, Button, SwipeZone, Svg, animated, useSpringValue } from 'react-drm';
+import React, { useContext, useEffect, useMemo, useRef, useState } from 'react';
+import { Box, Text, Button, SwipeZone, Svg, animated, useSpringValue, LayoutContext } from 'react-drm';
+import type { BoxNode } from 'react-drm';
 import {
   MdSkipPrevious, MdPlayArrow, MdPause, MdSkipNext,
 } from 'react-icons/md';
-import { useMediaPlayers } from '../../hooks/useMediaPlayers';
+import { type MediaPlayer, useMediaPlayers } from '../../hooks/useMediaPlayers';
 import { useAlbumArt } from '../../hooks/useAlbumArt';
 import { FaChevronLeft, FaChevronRight } from 'react-icons/fa6';
 
 const ACCENT: Record<string, string> = {
   spotify: '#1db954',
-  chrome:  '#4285f4',
+  browser: '#4285f4',
 };
 
 const FONT = '';
+
+function hms(us: number): string {
+  const s = Math.max(0, Math.floor(us / 1e6));
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = s % 60;
+  if (h > 0) return `${h}:${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+  return `${m}:${String(sec).padStart(2, '0')}`;
+}
 
 // Build the vinyl record as one cached SVG: black disc, a few groove rings, the
 // album art clipped to a circle (when present), a colored center label and the
@@ -70,6 +80,149 @@ function Vinyl({ size, accent, artUrl, spinning }: { size: number; accent: strin
     <animated.Box style={{ width: size, height: size, rotate: spin }}>
       <Svg src={markup} width={size} height={size} />
     </animated.Box>
+  );
+}
+
+function MediaPlayerSlide({
+  player,
+  itemWidth,
+  height,
+  iconSz,
+  color,
+}: {
+  player: MediaPlayer;
+  itemWidth: number;
+  height: number;
+  iconSz: number;
+  color: string;
+}) {
+  const [dragUs, setDragUs] = useState<number | null>(null);
+  const layoutCtx = useContext(LayoutContext);
+  const barRef = useRef<BoxNode | null>(null);
+
+  const shownUs = dragUs ?? player.state.positionUs;
+  const pct = player.state.lengthUs > 0 ? Math.max(0, Math.min(1, shownUs / player.state.lengthUs)) : 0;
+  const fillW = Math.round(Math.max(0, itemWidth - 450) * pct);
+  const barW = Math.max(140, itemWidth - 450);
+
+  const previewAt = (tx: number) => {
+    const lb = barRef.current ? layoutCtx.current.get(barRef.current) : undefined;
+    if (!lb || lb.w <= 0 || player.state.lengthUs <= 0) return;
+    const frac = Math.max(0, Math.min(1, (tx - lb.x) / lb.w));
+    setDragUs(Math.round(frac * player.state.lengthUs));
+  };
+
+  const commitDrag = (tx: number) => {
+    const lb = barRef.current ? layoutCtx.current.get(barRef.current) : undefined;
+    if (!lb || lb.w <= 0 || player.state.lengthUs <= 0) {
+      setDragUs(null);
+      return;
+    }
+    const frac = Math.max(0, Math.min(1, (tx - lb.x) / lb.w));
+    player.seek(Math.round(frac * player.state.lengthUs));
+    setDragUs(null);
+  };
+
+  return (
+    <Box
+      key={player.service}
+      style={{
+        width: itemWidth,
+        height,
+        flexDirection: 'row',
+        alignItems: 'center',
+        gap: 6,
+        paddingLeft: 8,
+        paddingRight: 8,
+        borderRadius: 8,
+      }}
+    >
+      <Button
+        width={60}
+        height={height}
+        color="#4f4b4f"
+        activeColor="#666666"
+        style={{ alignItems: 'center', justifyContent: 'center', borderRadius: 6 }}
+        onClick={player.previous}
+      >
+        <MdSkipPrevious style={{ width: iconSz, height: iconSz }} fill="#fff" />
+      </Button>
+
+      <Button
+        width={100}
+        height={height}
+        color={color}
+        onClick={player.playPause}
+        style={{ alignItems: 'center', justifyContent: 'center', borderRadius: 6 }}
+      >
+        {player.state.status === 'Playing'
+          ? <MdPause style={{ width: iconSz, height: iconSz }} fill="#fff" />
+          : <MdPlayArrow style={{ width: iconSz, height: iconSz }} fill="#fff" />
+        }
+      </Button>
+
+      <Button
+        width={60}
+        height={height}
+        color="#4f4b4f"
+        activeColor="#666666"
+        style={{ alignItems: 'center', justifyContent: 'center', borderRadius: 6 }}
+        onClick={player.next}
+      >
+        <MdSkipNext style={{ width: iconSz, height: iconSz }} fill="#fff" />
+      </Button>
+
+      <Vinyl
+        size={Math.round(height * 0.9)}
+        accent={color}
+        artUrl={player.state.artUrl}
+        spinning={player.state.status === 'Playing'}
+      />
+
+      <Box style={{ flex: 1, flexDirection: 'column', justifyContent: 'center', gap: 4 }}>
+        <Text color="#fff" fontSize={15} fontFamily={FONT}>
+          {player.state.title || 'Unknown'}
+        </Text>
+
+        <Text color="#94a3b8" fontSize={12} fontFamily={FONT}>
+          {player.state.artist}
+        </Text>
+
+        <Box style={{ flexDirection: 'row', alignItems: 'center', gap: 6 }}>
+          <Box style={{ width: 42, alignItems: 'flex-end' }}>
+            <Text color="#94a3b8" fontSize={11} fontFamily={FONT}>{hms(shownUs)}</Text>
+          </Box>
+
+          <Button
+            width={barW}
+            height={10}
+            color="transparent"
+            activeColor="transparent"
+            onTouchStart={(tx) => previewAt(tx)}
+            onTouchMove={(tx) => previewAt(tx)}
+            onTouchEnd={(tx) => commitDrag(tx)}
+            onTouchCancel={() => setDragUs(null)}
+          >
+            <Box
+              ref={barRef}
+              style={{
+                width: barW,
+                height: 6,
+                borderRadius: 6,
+                backgroundColor: '#1f2937',
+                overflow: 'hidden',
+              }}
+            >
+              <Box style={{ position: 'absolute', left: 0, top: 0, width: fillW, height: 6, borderRadius: 6, backgroundColor: color }} />
+            </Box>
+          </Button>
+
+          <Box style={{ width: 42 }}>
+            <Text color="#94a3b8" fontSize={11} fontFamily={FONT}>{hms(player.state.lengthUs)}</Text>
+          </Box>
+        </Box>
+      </Box>
+    </Box>
   );
 }
 
@@ -164,81 +317,16 @@ const prev = () => {
             }}
           >
 
-            {players.map((player) => {
-              const color = ACCENT[player.name] ?? '#666';
-
-              return (
-                <Box
-                  key={player.service}
-                  style={{
-                    width: itemWidth,
-                    height,
-                    flexDirection: 'row',
-                    alignItems: 'center',
-                    gap: 6,
-                    paddingLeft: 8,
-                    paddingRight: 8,
-                    borderRadius: 8,
-                    // backgroundColor: i === 0 ? 'red' : 'blue',
-                  }}
-                >
-
-                  {/* prev */}
-                  <Button
-                    width={60}
-                    height={height}
-                    color="#4f4b4f" activeColor="#666666" style={{ alignItems: 'center', justifyContent: 'center', borderRadius: 6 }}
-                    onClick={player.previous}
-                  >
-                    <MdSkipPrevious style={{ width: iconSz, height: iconSz }} fill='#fff' />
-                  </Button>
-
-                  {/* play/pause */}
-                  <Button
-                    width={100}
-                    height={height}
-                    color={color}
-                    onClick={player.playPause}
-                    style={{ alignItems: 'center', justifyContent: 'center', borderRadius: 6 }}
-                  >
-                    {player.state.status === 'Playing'
-                      ? <MdPause style={{ width: iconSz, height: iconSz }} fill="#fff" />
-                      : <MdPlayArrow style={{ width: iconSz, height: iconSz }} fill="#fff" />
-                    }
-                  </Button>
-
-                  {/* next */}
-                  <Button
-                    width={60}
-                    height={height}
-                    color="#4f4b4f" activeColor="#666666" style={{ alignItems: 'center', justifyContent: 'center', borderRadius: 6 }}
-                    onClick={player.next}
-                  >
-                    <MdSkipNext style={{ width: iconSz, height: iconSz }} fill="#fff" />
-                  </Button>
-
-                  {/* spinning vinyl with album art */}
-                  <Vinyl
-                    size={Math.round(height * 0.9)}
-                    accent={color}
-                    artUrl={player.state.artUrl}
-                    spinning={player.state.status === 'Playing'}
-                  />
-
-                  {/* text */}
-                  <Box style={{ flexDirection: 'column' }}>
-                    <Text color="#fff" fontSize={15} fontFamily={FONT}>
-                      {player.state.title || 'Unknown'}
-                    </Text>
-
-                    <Text color="#94a3b8" fontSize={12} fontFamily={FONT}>
-                      {player.state.artist}
-                    </Text>
-                  </Box>
-
-                </Box>
-              );
-            })}
+            {players.map((player) => (
+              <MediaPlayerSlide
+                key={player.service}
+                player={player}
+                itemWidth={itemWidth}
+                height={height}
+                iconSz={iconSz}
+                color={ACCENT[player.name] ?? '#666'}
+              />
+            ))}
 
           </Box>
         </SwipeZone>


### PR DESCRIPTION
 - use `plasma-browser-integration` as the browser media source
 - show current position and total duration in the media panel
 - add a progress bar with seek support
 - poll browser metadata periodically so tab switches within the same browser session update the touchbar reliably
 - keep Spotify support unchanged
 - tested on Chromium (rpm/flatpak) and Firefox on Fedora
 - Browsers installed with Flatpak won't see manifest json, thus will not work - needs mention in readme