### PR TITLE
fix(assets): copy assets to dist during build and fix README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Supported installer environments:
 - Ubuntu 25.10 or newer and Ubuntu derivatives that provide Node.js 20.19.0
   or newer
 - Arch Linux and supported Arch derivatives
-- GNOME, KDE Plasma , Niri or Hyprland on Wayland
+- GNOME, KDE Plasma, Niri or Hyprland on Wayland
 - Any Xorg desktop with `xprop`
 
 Ubuntu 24.04 is not supported because its repositories provide Node.js 18.
@@ -103,11 +103,12 @@ modinfo hid-appletb-bl
 Stop, disable and remove `tiny-dfr`, `mac-touchbar-plus` or any other Touch Bar
 daemon using the method appropriate for your distribution.
 
-Build from the repository root. `npm ci` uses the root lockfile and installs
-the root package together with the `linux-touchbar-control-center` workspace:
+Build the control center workspace. `npm ci` must be run from the repository root
+to use the root lockfile:
 
 ```sh
 npm ci
+cd linux-touchbar-control-center
 npm run build
 ```
 

--- a/linux-touchbar-control-center/package.json
+++ b/linux-touchbar-control-center/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "dev": "tsx --conditions=development index.tsx",
     "dev:profile": "DRM_DAMAGE_LOG=1 REACT_DRM_PROFILE=1 tsx --conditions=development index.tsx",
-    "build": "npm --prefix .. run build && tsc -p tsconfig.json",
+    "build": "npm --prefix .. run build && tsc -p tsconfig.json && rm -rf dist/assets && cp -r assets dist/",
     "start": "NODE_ENV=production node ./dist/index.js"
   },
   "dependencies": {


### PR DESCRIPTION
The keyboard illumination SVG icons in `mediaScreen.tsx` were missing in the Touch Bar when running the production build. The component relies on `__dirname` to dynamically resolve paths (`path.join(__dirname, '..', 'assets')`), which resolves to `dist/assets` after compilation, but the `assets` directory was not included in the output folder.

Resolved by adding a step in the `build` script to copy the `assets` directory to `dist`, ensuring all dynamically resolved assets are present in the final build. The command has been made idempotent so it handles repeated builds safely.

Also corrected manual build instructions in README.md and fixed a typo in the supported compositor list.