### PR TITLE
fix: export display backlight candidates

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export { render } from './renderer/renderer';
+export { DISPLAY_BACKLIGHT_NAMES } from './renderer/renderer';
 export type { RenderResult } from './renderer/renderer';
 export { Box } from './components/Box';
 export { Text } from './components/Text';

--- a/src/renderer/renderer.ts
+++ b/src/renderer/renderer.ts
@@ -351,7 +351,7 @@ function watchLid(onLid: (closed: boolean) => void): () => void {
 // the panel off and wake from off reliably restores it.
 
 const TB_BACKLIGHT_NAMES  = ['display-pipe', 'appletb_backlight'];
-const DISP_BACKLIGHT_NAMES = ['apple-panel-bl', 'gmux_backlight', 'intel_backlight', 'acpi_video0'];
+export const DISPLAY_BACKLIGHT_NAMES = ['apple-panel-bl', 'gmux_backlight', 'intel_backlight', 'acpi_video0'];
 
 // After resume the appletb_backlight HID interface re-binds late; re-apply and
 // verify the level on this cadence until the panel confirms it (or the window
@@ -385,7 +385,7 @@ class Backlight {
     this.tbDir   = findBacklightDir(TB_BACKLIGHT_NAMES);
     this.tbFile  = this.tbDir ? `${this.tbDir}/brightness` : null;
     this.tbMax   = this.tbDir ? readInt(`${this.tbDir}/max_brightness`) : 0;
-    const dispDir = findBacklightDir(DISP_BACKLIGHT_NAMES);
+    const dispDir = findBacklightDir(DISPLAY_BACKLIGHT_NAMES);
     this.dispFile = dispDir ? `${dispDir}/brightness` : null;
     this.dispMax  = dispDir ? readInt(`${dispDir}/max_brightness`) : 0;
   }
@@ -457,7 +457,7 @@ class Backlight {
   reopen(): void {
     this.resolveTb();
 
-    const dispDir = findBacklightDir(DISP_BACKLIGHT_NAMES);
+    const dispDir = findBacklightDir(DISPLAY_BACKLIGHT_NAMES);
     this.dispFile = dispDir ? `${dispDir}/brightness` : null;
     this.dispMax  = dispDir ? readInt(`${dispDir}/max_brightness`) : 0;
 


### PR DESCRIPTION
## Summary

- export the renderer's display backlight candidate list as `DISPLAY_BACKLIGHT_NAMES`
- expose it from the package entry point for control-center consumers
- keep renderer lookups on the same exported constant as a single source of truth

## Why

The Linux Touch Bar control center imports `DISPLAY_BACKLIGHT_NAMES` from `react-drm`, but the package did not export it. This caused the production TypeScript build to fail with `TS2305`.

## Verification

- `npm run build` from `linux-touchbar-control-center`
- verified the production daemon on a T2 MacBookPro16,1 running Omarchy/Hyprland: the `appletbdrm` 2008x60 display, Touch Bar digitizer, display/Touch Bar backlights, PipeWire volume backend, and Hyprland IPC initialized successfully

Closes #27 