### PR TITLE
fix: preserve held Touch Bar function keys

### DIFF
--- a/linux-touchbar-control-center/app/fnkeys/page.tsx
+++ b/linux-touchbar-control-center/app/fnkeys/page.tsx
@@ -1,7 +1,8 @@
-import React, { useContext } from 'react';
-import { Box, Text, Button, KEY, DisplaySizeContext } from 'react-drm';
+import React, { useContext, useMemo } from 'react';
+import { Box, Text, Button, FKEY_CODES, KEY, DisplaySizeContext } from 'react-drm';
 import { BackButton } from '@/components/BackButton';
 import { keys } from '@/lib/services/keyInjector';
+import { createHeldKeyHandlers } from '@/lib/services/heldKey';
 import { ESC_KEY, FN_KEYS } from '@/lib/utils/configLoader';
 import type { LayerConfig } from '@/lib/routes/loadRoutes';
 
@@ -22,6 +23,21 @@ const keyStyle = {
   borderBottomRightRadius: 10,
 } as const;
 
+function HeldKey({ label, keyCode }: { label: string; keyCode: number }) {
+  const handlers = useMemo(() => createHeldKeyHandlers(keys, keyCode), [keyCode]);
+
+  return (
+    <Button
+      color="#373737"
+      activeColor="#474747"
+      style={keyStyle}
+      {...handlers}
+    >
+      <Text fontSize={24} fontFamily="monospace" style={{ fontWeight: '700' }}>{label}</Text>
+    </Button>
+  );
+}
+
 export default function FnKeys({ width, height }: { width: number; height: number }) {
   // On wide displays without a physical Esc key, 'fn' mode adds Esc as the
   // first key in this row (sized like the F-keys). Uses the auto-detected
@@ -35,39 +51,27 @@ export default function FnKeys({ width, height }: { width: number; height: numbe
       {/* <BackButton /> */}
 
       {showEsc && (
-        <Button
+        <HeldKey
           key="esc"
-          color="#373737"
-          activeColor="#474747"
-          style={keyStyle}
-          onClick={() => keys.pressKey(KEY.ESC)}
-        >
-          <Text  fontSize={24} fontFamily="monospace" style={{ fontWeight: '700' }}>esc</Text>
-        </Button>
+          label="esc"
+          keyCode={KEY.ESC}
+        />
       )}
 
       {KEYS.map((key, i) => (
-        <Button
+        <HeldKey
           key={key}
-          color="#373737"
-          activeColor="#474747"
-          style={keyStyle}
-          onClick={() => keys.pressF((i + 1) as 1|2|3|4|5|6|7|8|9|10|11|12)}
-        >
-          <Text  fontSize={24} fontFamily="monospace" style={{ fontWeight: '700' }}>{key}</Text>
-        </Button>
+          label={key}
+          keyCode={FKEY_CODES[i]}
+        />
       ))}
 
       {FN_KEYS.extra.map(k => (
-        <Button
+        <HeldKey
           key={k.label}
-          color="#373737"
-          activeColor="#474747"
-          style={keyStyle}
-          onClick={() => keys.pressKey(k.key)}
-        >
-          <Text  fontSize={24} fontFamily="monospace" style={{ fontWeight: '700' }}>{k.label}</Text>
-        </Button>
+          label={k.label}
+          keyCode={k.key}
+        />
       ))}
 
     </Box>

--- a/linux-touchbar-control-center/lib/services/heldKey.ts
+++ b/linux-touchbar-control-center/lib/services/heldKey.ts
@@ -1,0 +1,24 @@
+export interface KeyStateInjector {
+  keyDown(code: number): void;
+  keyUp(code: number): void;
+}
+
+export function createHeldKeyHandlers(injector: KeyStateInjector, keyCode: number) {
+  let held = false;
+
+  const release = () => {
+    if (!held) return;
+    held = false;
+    injector.keyUp(keyCode);
+  };
+
+  return {
+    onTouchStart: () => {
+      if (held) return;
+      held = true;
+      injector.keyDown(keyCode);
+    },
+    onTouchEnd: release,
+    onTouchCancel: release,
+  };
+}

--- a/linux-touchbar-control-center/package.json
+++ b/linux-touchbar-control-center/package.json
@@ -7,6 +7,7 @@
     "dev:profile": "DRM_DAMAGE_LOG=1 REACT_DRM_PROFILE=1 tsx --conditions=development index.tsx",
     "dev:preview": "REACT_DRM_BACKEND=preview tsx --conditions=development index.tsx",
     "build": "npm --prefix .. run build && rm -rf dist && tsc -p tsconfig.json && tsc-alias -p tsconfig.json && cp -r assets dist/",
+    "test": "tsx --test tests/*.test.ts",
     "start": "NODE_ENV=production node ./dist/index.js",
     "start:preview": "NODE_ENV=production REACT_DRM_BACKEND=preview node ./dist/index.js"
   },

--- a/linux-touchbar-control-center/tests/heldKey.test.ts
+++ b/linux-touchbar-control-center/tests/heldKey.test.ts
@@ -1,0 +1,45 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import { createHeldKeyHandlers } from '../lib/services/heldKey';
+
+function setup() {
+  const events: string[] = [];
+  const handlers = createHeldKeyHandlers({
+    keyDown: code => events.push(`down:${code}`),
+    keyUp: code => events.push(`up:${code}`),
+  }, 67);
+
+  return { events, handlers };
+}
+
+test('holds a key from touch start until touch end', () => {
+  const { events, handlers } = setup();
+
+  handlers.onTouchStart();
+  assert.deepEqual(events, ['down:67']);
+
+  handlers.onTouchEnd();
+  assert.deepEqual(events, ['down:67', 'up:67']);
+});
+
+test('releases a held key once when the gesture is cancelled', () => {
+  const { events, handlers } = setup();
+
+  handlers.onTouchStart();
+  handlers.onTouchStart();
+  handlers.onTouchCancel();
+  handlers.onTouchEnd();
+
+  assert.deepEqual(events, ['down:67', 'up:67']);
+});
+
+test('can hold the same key again after release', () => {
+  const { events, handlers } = setup();
+
+  handlers.onTouchStart();
+  handlers.onTouchEnd();
+  handlers.onTouchStart();
+  handlers.onTouchEnd();
+
+  assert.deepEqual(events, ['down:67', 'up:67', 'down:67', 'up:67']);
+});

--- a/linux-touchbar-control-center/tsconfig.json
+++ b/linux-touchbar-control-center/tsconfig.json
@@ -9,5 +9,5 @@
   },
   "references": [{ "path": ".." }],
   "include": ["./**/*"],
-  "exclude": ["node_modules", "dist"]
+  "exclude": ["node_modules", "dist", "tests"]
 }

--- a/native/src/key_injector.cpp
+++ b/native/src/key_injector.cpp
@@ -46,6 +46,8 @@ static const int EXTRA_KEYS[] = {
 
 Napi::Object KeyInjector::Init(Napi::Env env, Napi::Object exports) {
   Napi::Function func = DefineClass(env, "KeyInjector", {
+    InstanceMethod("keyDown",    &KeyInjector::KeyDown),
+    InstanceMethod("keyUp",      &KeyInjector::KeyUp),
     InstanceMethod("pressKey",   &KeyInjector::PressKey),
     InstanceMethod("pressCombo", &KeyInjector::PressCombo),
   });
@@ -99,11 +101,34 @@ void KeyInjector::SendEvent(uint16_t type, uint16_t code, int32_t value) {
   write(fd_, &ev, sizeof(ev));
 }
 
+void KeyInjector::SendKeyState(int keycode, int value) {
+  SendEvent(EV_KEY, keycode, value);
+  SendEvent(EV_SYN, SYN_REPORT, 0);
+}
+
 void KeyInjector::SendKey(int keycode) {
-  SendEvent(EV_KEY, keycode, 1);
-  SendEvent(EV_SYN, SYN_REPORT, 0);
-  SendEvent(EV_KEY, keycode, 0);
-  SendEvent(EV_SYN, SYN_REPORT, 0);
+  SendKeyState(keycode, 1);
+  SendKeyState(keycode, 0);
+}
+
+Napi::Value KeyInjector::KeyDown(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsNumber()) {
+    Napi::TypeError::New(env, "keyDown(keycode: number)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  if (fd_ >= 0) SendKeyState(info[0].As<Napi::Number>().Int32Value(), 1);
+  return env.Undefined();
+}
+
+Napi::Value KeyInjector::KeyUp(const Napi::CallbackInfo& info) {
+  Napi::Env env = info.Env();
+  if (info.Length() < 1 || !info[0].IsNumber()) {
+    Napi::TypeError::New(env, "keyUp(keycode: number)").ThrowAsJavaScriptException();
+    return env.Undefined();
+  }
+  if (fd_ >= 0) SendKeyState(info[0].As<Napi::Number>().Int32Value(), 0);
+  return env.Undefined();
 }
 
 Napi::Value KeyInjector::PressKey(const Napi::CallbackInfo& info) {

--- a/native/src/key_injector.h
+++ b/native/src/key_injector.h
@@ -9,10 +9,13 @@ public:
   ~KeyInjector();
 
 private:
+  Napi::Value KeyDown(const Napi::CallbackInfo& info);
+  Napi::Value KeyUp(const Napi::CallbackInfo& info);
   Napi::Value PressKey(const Napi::CallbackInfo& info);
   Napi::Value PressCombo(const Napi::CallbackInfo& info);
 
   void SendEvent(uint16_t type, uint16_t code, int32_t value);
+  void SendKeyState(int keycode, int value);
   void SendKey(int keycode);
   void SendCombo(const std::vector<int>& keycodes);
 

--- a/src/native/input.ts
+++ b/src/native/input.ts
@@ -20,6 +20,8 @@ interface NativeTouchReader {
 }
 
 interface NativeKeyInjector {
+  keyDown(keycode: number): void;
+  keyUp(keycode: number): void;
   pressKey(keycode: number): void;
   pressCombo(keycodes: number[]): void;
 }
@@ -264,6 +266,14 @@ export class KeyInjector {
 
   pressIndex(idx: number): void {
     this.handle.pressKey(FKEY_CODES[idx]);
+  }
+
+  keyDown(code: number): void {
+    this.handle.keyDown(code);
+  }
+
+  keyUp(code: number): void {
+    this.handle.keyUp(code);
   }
 
   pressKey(code: number): void {


### PR DESCRIPTION
## Summary

- add separate key-down and key-up operations to the uinput injector
- hold Fn-layer keys from touch start until touch end or cancellation
- guard duplicate starts/releases and cover the lifecycle with unit tests

## Verification

- `npm run build`
- `npm test --workspace linux-touchbar-control-center`
- full production control-center build, stacked locally on #28 because current master is missing the backlight export
- grabbed-uinput integration test captured F9 down and up 1.200 seconds apart
- rebuilt `react-drm.service` is active with the DRM display, touch reader, and virtual keyboard attached